### PR TITLE
Replace gitlab links with github for repos hosting consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 Setting up a workspace for ROS2 Humble for QNX:
 
-Pre-requisite: build and install QNX ROS2 Humble from [source](https://gitlab.com/qnx/ports/build-files/-/blob/main/ports/ros2/README.md).
+Pre-requisite: build and install QNX ROS2 Humble from [source](https://github.com/qnx-ports/build-files/blob/main/ports/ros2/README.md).                                     
 
 Preferable host OS: Ubuntu 20.04
 
-0. Optional: use [Docker](https://gitlab.com/qnx/ports/build-files/-/blob/main/docker/README.md) to have a consistent build environment.
+0. Optional: use [Docker](https://github.com/qnx-ports/build-files/blob/main/docker/README.md) to have a consistent build environment.
 
 1. Clone the sample workspace:
 ```bash
-git clone https://gitlab.com/qnx/sample-apps/qnx-ros2-workspace.git && cd qnx-ros2-workspace
+git clone https://github.com/qnx-ports/qnx-ros2-workspace.git && cd qnx-ros2-workspace
 ```
 
 2. This repository has a hello_qnx in src as an example. Add your packages inside src.


### PR DESCRIPTION
As GitLab [qnx-port](https://gitlab.com/qnx/ports/build-files/-/tree/main) repository is deprecated, the pull request fixes leftovers in the links to improve repositories consistency.